### PR TITLE
Fixed nil service data when braodcast by device

### DIFF
--- a/ios/CBPeripheral+Extensions.m
+++ b/ios/CBPeripheral+Extensions.m
@@ -111,8 +111,11 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     NSLog(@"%@", serviceData);
     
     for (CBUUID *key in [serviceData allKeys]) {
-      [serviceData setObject:dataToArrayBuffer([serviceData objectForKey:key]) forKey:[key UUIDString]];
-      [serviceData removeObjectForKey:key];
+        [serviceData setObject:dataToArrayBuffer([serviceData objectForKey:key]) forKey:[key UUIDString]];
+        if ([serviceData objectForKey:key]) {
+            [serviceData setObject:dataToArrayBuffer([serviceData objectForKey:key]) forKey:[key UUIDString]];
+            [serviceData removeObjectForKey:key];
+        }
     }
 
     // replace the Service Data object


### PR DESCRIPTION
Raising this as there are times when nil service data is captured from external Bluetooth devices during a scan and hence cause a crash.

https://github.com/innoveit/react-native-ble-manager/pull/569
